### PR TITLE
Using tar.Unpack from tar@3.0.0 instead of tar.Extract from tar@2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/moos/wordnet-db.git"
   },
   "dependencies": {
-    "tar": "latest"
+    "tar": "3.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/unpack.js
+++ b/unpack.js
@@ -19,5 +19,5 @@ log("Extracting %s",tarball);
 fs.createReadStream(tarball)
   .on("error", log)
   .pipe(zlib.Unzip())
-  .pipe(tar.Extract({ path: __dirname }))
+  .pipe(tar.x({ path: __dirname }))
   .on("end", log);


### PR DESCRIPTION
Addresses issue #9 and fixes the function name change from tar@2.2.1 in tar@3.0.0