### PR TITLE
Updated the unpack.js script to use tar correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/moos/wordnet-db.git"
   },
   "dependencies": {
-    "tar": "latest"
+    "tar": "3.0.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/unpack.js
+++ b/unpack.js
@@ -19,5 +19,5 @@ log("Extracting %s",tarball);
 fs.createReadStream(tarball)
   .on("error", log)
   .pipe(zlib.Unzip())
-  .pipe(tar.Extract({ path: __dirname }))
+  .pipe(tar.extract({ path: __dirname }))
   .on("end", log);


### PR DESCRIPTION
The latest tar no longer uses a capitalized Extract(). Updated the function call and froze the version of tar.